### PR TITLE
regarding #1099 — improves palettechoser style

### DIFF
--- a/core/wiki/paletteswitcher.tid
+++ b/core/wiki/paletteswitcher.tid
@@ -6,7 +6,8 @@ title: $:/snippets/paletteswitcher
 </div>
 
 <$linkcatcher to="$:/palette">
-<div class="tc-chooser"><$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[description]]"><div class="tc-chooser-item"><$link to={{!!title}}><div><$reveal state="$:/palette" type="match" text={{!!title}}>&bull;</$reveal><$reveal state="$:/palette" type="nomatch" text={{!!title}}>&nbsp;</$reveal> ''<$view field="name" format="text"/>'' - <$view field="description" format="text"/></div><$transclude tiddler="$:/snippets/currpalettepreview"/></$link></div>
+<div class="tc-chooser"><$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[description]]"><$set name="cls" filter="[{!!title}field:title{$:/palette}]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item"><div class=<<cls>>><$link to={{!!title}}><div>''<$view field="name" format="text"/>'' - <$view field="description" format="text"/></div><$transclude tiddler="$:/snippets/currpalettepreview"/></$link>
+</div></$set>
 </$list>
 </div>
 </$linkcatcher>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1461,7 +1461,7 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-sidebar-lists .tc-tab-buttons button {
-	background-color: <<colour sidebar-tab-background>>;
+	background-color: <<colour tab-background>>;
 	color: <<colour sidebar-tab-foreground>>;
 	border-left: 1px solid <<colour sidebar-tab-border>>;
 	border-top: 1px solid <<colour sidebar-tab-border>>;
@@ -1681,11 +1681,24 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 	padding: 2px 4px;
 }
 
+.tc-chooser-item.tc-chosen {
+	background-color: <<colour sidebar-tab-background>>
+}
+
+.tc-chooser-item a.tc-tiddlylink > div:first-child {
+	padding-left:10px;
+}
+
+.tc-chooser-item.tc-chosen a.tc-tiddlylink > div:first-child:before {
+	margin-left:-10px;
+	content: "» ";
+}
+
 .tc-chooser-item a.tc-tiddlylink {
 	display: block;
 	text-decoration: none;
 	color: <<colour tiddler-link-foreground>>;
-	background-color: <<colour tiddler-link-background>>;
+	background-color: transparent;
 }
 
 .tc-chooser-item a.tc-tiddlylink:hover {


### PR DESCRIPTION
depends on a properly refreshing set widget, see #1952

allows to override styles more easily via new class tc-chosen