### PR TITLE
stop tm-delete-tiddler to confirm deleting states or temporary tiddlers

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -258,7 +258,11 @@ NavigatorWidget.prototype.handleDeleteTiddlerEvent = function(event) {
 		confirmationTitle = title;
 	}
 	// Seek confirmation
-	if((this.wiki.getTiddler(originalTitle) || (tiddler.fields.text || "") !== "") && !confirm($tw.language.getString(
+	if(
+	  	(this.wiki.getTiddler(originalTitle) || (tiddler.fields.text || "") !== "") &&
+		confirmationTitle.indexOf("$:/temp/") !== 0 &&
+		confirmationTitle.indexOf("$:/state/") !== 0 &&
+		!confirm($tw.language.getString(
 				"ConfirmDeleteTiddler",
 				{variables:
 					{title: confirmationTitle}


### PR DESCRIPTION
allows to use the keyboard widget to delete temp and state tiddlers when escaping out of a custom editor