### PR TITLE
 suggestion for palettswitcher styles

### DIFF
--- a/core/ui/ControlPanel/Toolbars/EditToolbar.tid
+++ b/core/ui/ControlPanel/Toolbars/EditToolbar.tid
@@ -12,7 +12,7 @@ $:/config/EditToolbarButtons/Visibility/$(listItem)$
 <$set name="tv-config-toolbar-icons" value="yes">
 <$set name="tv-config-toolbar-text" value="yes">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditToolbar]!has[draft.of]]" variable="listItem">
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show">
+<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show" class="tc-check-list">
 <$transclude tiddler=<<listItem>> field="caption"/>
 <i class="tc-muted">
 --

--- a/core/ui/ControlPanel/Toolbars/EditorToolbar.tid
+++ b/core/ui/ControlPanel/Toolbars/EditorToolbar.tid
@@ -9,7 +9,7 @@ $:/config/EditorToolbarButtons/Visibility/$(listItem)$
 \end
 
 \define toolbar-button()
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show">
+<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show" class="tc-check-list">
 <$transclude tiddler={{$(listItem)$!!icon}}/>
 <$transclude tiddler=<<listItem>> field="caption"/>
 <i class="tc-muted">

--- a/core/ui/ControlPanel/Toolbars/PageControls.tid
+++ b/core/ui/ControlPanel/Toolbars/PageControls.tid
@@ -12,7 +12,7 @@ $:/config/PageControlButtons/Visibility/$(listItem)$
 <$set name="tv-config-toolbar-icons" value="yes">
 <$set name="tv-config-toolbar-text" value="yes">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show">
+<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show" class="tc-check-list">
 <$transclude tiddler=<<listItem>> field="caption"/>
 <i class="tc-muted">
 --

--- a/core/ui/ControlPanel/Toolbars/ViewToolbar.tid
+++ b/core/ui/ControlPanel/Toolbars/ViewToolbar.tid
@@ -12,7 +12,7 @@ $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 <$set name="tv-config-toolbar-icons" value="yes">
 <$set name="tv-config-toolbar-text" value="yes">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]]" variable="listItem">
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show">
+<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show" class="tc-check-list">
 <$transclude tiddler=<<listItem>> field="caption"/>
 <i class="tc-muted">
 --

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -135,6 +135,10 @@ input:not([type]) {
 	background: <<colour background>>;
 }
 
+input[type="checkbox"] {
+  vertical-align: middle;
+}
+
 .tc-muted {
 	color: <<colour muted-foreground>>;
 }
@@ -627,11 +631,6 @@ button.tc-untagged-label {
 
 .tc-page-controls {
 	margin-top: 14px;
-}
-
-.tc-page-controls > span > button,
-.tc-page-controls > span > span > button{
-	font-size: 1.5em;
 }
 
 .tc-page-controls button {
@@ -1877,6 +1876,18 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 
 .tc-plugin-info-dropdown-body {
 	padding: 1em 1em 1em 1em;
+}
+
+/*
+** Checkbox tiddlers transcluded into ControlPanel. see: #1954
+*/
+
+.tc-check-list {
+	line-height: 2em;
+}
+
+.tc-check-list .tc-image-button {
+	height: 1.5em;
 }
 
 /*


### PR DESCRIPTION
make tiddler and ControlPanel view behave the same. add generic tc-check-list setting. add generic input type checklist, vertical alignment.

http://1954.tiddlyspot.com/#%24%3A%2Fcore%2Fui%2FControlPanel%2FToolbars%2FEditorToolbar:%24%3A%2Fcore%2Fui%2FControlPanel%2FToolbars%2FEditorToolbar%20%24%3A%2FControlPanel

Those two tiddlers should look the same, with my settings. 
If you move. $:/core/ui/ControlPanel/Toolbars/EditorToolbar to the sidebar it still works nicely!
